### PR TITLE
Remove DJI Camera exposure Widget

### DIFF
--- a/DronelinkDJIUI/DronelinkDJIUI.swift
+++ b/DronelinkDJIUI/DronelinkDJIUI.swift
@@ -65,10 +65,6 @@ open class DJIWidgetFactory: WidgetFactory {
         (current as? WrapperWidget)?.viewController is DUXCameraSettingsController ? current : DUXCameraSettingsController().createWidget()
     }
 
-    open override func createCameraExposureWidget(current: Widget? = nil) -> Widget? {
-        current?.view.subviews.first is DUXCameraConfigInfoWidget ? current : DUXCameraConfigInfoWidget().createWidget()
-    }
-
     open override func createCameraStorageWidget(current: Widget? = nil) -> Widget? {
         current?.view.subviews.first is DUXCameraConfigStorageWidget ? current : DUXCameraConfigStorageWidget().createWidget()
     }


### PR DESCRIPTION
Removed this widget so the app uses the dronelink-core-ui instead